### PR TITLE
Solve problem with current rmagick version 4.2.2

### DIFF
--- a/lib/easy_captcha/generator/default.rb
+++ b/lib/easy_captcha/generator/default.rb
@@ -61,7 +61,7 @@ module EasyCaptcha
         require 'rmagick' unless defined?(Magick)
 
         config = self
-        canvas = Magick::Image.new(EasyCaptcha.image_width, EasyCaptcha.image_height) do |variable|
+        canvas = Magick::Image.new(EasyCaptcha.image_width, EasyCaptcha.image_height) do
           self.background_color = config.image_background_color unless config.image_background_color.nil?
           self.background_color = 'none' if config.background_image.present?
         end


### PR DESCRIPTION
It seems that easy_captcha is not working properly with the current version of the rmagick gem 4.2.2.
The following exception is thrown:
```
 Exception: NoMethodError: undefined method `background_color=' for #<EasyCaptcha::Generator::Default:0x0000564a23cea4f0>
Did you mean?  background_image=
```

The proposed change should be able to solve this problem.